### PR TITLE
docs: polish README for marketplace listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,71 @@
 # kibot-config
 
-Kibot config is meant for building kicad pcb datapacks using github actions. While I have chosen a flexible license to for this project to allow the community to do what they want. I encourage anyone using this to make your project opensource.
+A GitHub Action plus a library of [KiBot](https://github.com/INTI-CMNB/KiBot) configs for building complete KiCad datapacks &mdash; drawings, gerbers, BOM, pick-and-place, 3D STEP, Blender renders, panels, and visual diffs &mdash; on every push.
 
-## Use case
+## Quick start
 
-I have indented for this repository to make building kicad pcb artifacts as easy as possible.
+In your KiCad project repo, drop a workflow at `.github/workflows/build-pcb.yaml`:
 
-### Step 1: Add Github Action
-
-Add `.github` folder to the root directory of the github repository.
-
-### Step 2: Add options.yaml
-
-Add `options.yaml` to the root directory of the github repository.
-
-### Step 3: Commit changes
-
-Commit changes.
-
-### Example 
-
-[Mad_RP2040](https://github.com/Cimos/Mad_RP2040/) is an example of how kibot-config can be used. 
-
-### Example project folder structure
-
-Your project folder structure will look something like the following.
-
-```text
-SomeProject/
-  .github/
-  SomeProject.kicad_pro
-  SomeProject.kicad_sch
-  SomeProject.kicad_pcb
-  options.yaml
-  panelization.yaml (Optional)
-
-  .github/
-    workflows/
-
-  workflows/
-    build-datapack.yaml
-    build-panel.yaml
+```yaml
+name: Build PCB datapack
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/checkout@v4
+        with:
+          repository: Cimos/kibot-config
+          path: kibot-config
+      - uses: Cimos/kibot-config@main
+        with:
+          config: kibot-config/build-pcb-kibot.yaml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pcb-datapack
+          path: output/
 ```
 
-## Future work
+Add an `options.yaml` at the root of your repo with your KiBot preflight overrides &mdash; see [Cimos/Mad_RP2040](https://github.com/Cimos/Mad_RP2040/) for a working example.
 
-* Add support for variants
-* Add 2d render generation
-* Add GIF generation
-* Add github action which calls a default action with the default `options.yaml` in this repository.
+## Project layout it expects
+
+```text
+your-kicad-project/
+├── your-project.kicad_pro
+├── your-project.kicad_sch
+├── your-project.kicad_pcb
+├── options.yaml              # required — preflight, filters, variants
+├── panelization.yaml         # optional — only if using build-panel
+└── .github/
+    └── workflows/
+        └── build-pcb.yaml
+```
+
+The action derives the project name from the first `*.kicad_pro` it finds at the repo root, so there's an implicit assumption of a single top-level KiCad project.
+
+## Bundled configs
+
+Point the action's `config:` input at one of these:
+
+| Config | What it builds |
+|---|---|
+| `build-pcb-kibot.yaml` | Drawings (schematic + PCB PDFs), gerbers per fab preset, BOM, pick-and-place, KiCost, stencils |
+| `build-3d_model-kibot.yaml` | 3D STEP export (simple + full) |
+| `build-2d_images-kibot.yaml` | 4× Blender renders (top/bottom × angled/straight) |
+| `build-video-kibot.yaml` | Rotating-PCB Blender frame sequence |
+| `build-diff-kibot.yaml` | KiRi + git-based PCB/SCH visual diffs |
+| `build-panel-kibot.yaml` | Drawings for an already-panelised board |
+
+Reference workflow templates for each live in [`.github/actions/`](.github/actions) of this repo &mdash; copy them into your own repo's `.github/workflows/` to wire up multi-job builds.
+
+## Example
+
+[Cimos/Mad_RP2040](https://github.com/Cimos/Mad_RP2040/) is a real KiCad project using kibot-config end-to-end. Browse its `.github/workflows/` and `options.yaml` to see how the pieces fit together.
+
+## License
+
+I've chosen a permissive license so the community can use this freely. If you build something with it, I encourage you to open-source your project in return.


### PR DESCRIPTION
## Summary

- Rewrites the README so it reads well as both the GitHub Marketplace listing body and the repo landing page on github.com.
- Fixes typos (indented → intended, to to → to, Kibot → KiBot, kicad → KiCad), replaces the vague three-step setup with a copy-paste workflow snippet, and redraws the broken project-layout tree (the previous version had `.github/` duplicated and a stray top-level `workflows/`).
- Adds a table mapping each bundled `build-*-kibot.yaml` to the artifacts it produces — that's the value of the repo and wasn't surfaced anywhere previously.
- Drops the stale "Future work" section: variants, 2D renders, video/GIF, and the `quickstart` input are all already implemented on `main`.

Prep step ahead of publishing the action to the GitHub Marketplace as **KiCad Datapack Builder** (renamed in 5ed66a3).

## Test plan

- [ ] Preview rendered README on github.com (Files tab → README.md) — check tree formatting, table rendering, code-fence languages.
- [ ] Spot-check internal links: \`.github/actions/\` directory link, \`Cimos/Mad_RP2040\` external link.
- [ ] Confirm the workflow snippet copy-pastes into a fresh KiCad repo and runs (deferred to post-merge — out of scope for the docs PR itself).